### PR TITLE
add custom exception with detailed error information for non 200 responses

### DIFF
--- a/Graphite/Exceptions/HttpRequestException.cs
+++ b/Graphite/Exceptions/HttpRequestException.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Net;
+using System.Runtime.Serialization;
+
+namespace ahd.Graphite.Exceptions
+{
+    [Serializable]
+    public class HttpRequestException: System.Net.Http.HttpRequestException
+    {
+        public HttpRequestException(HttpStatusCode statuscode, string response):base()
+        {
+            StatusCode = statuscode;
+            Response = response;
+        }
+
+        public HttpRequestException(string response, string message):base(message)
+        {
+            Response = response;
+        }
+
+        public HttpRequestException(string response, string message, Exception inner):base(message, inner)
+        {
+            Response = response;
+        }
+
+        public HttpStatusCode StatusCode { get; private set; }
+
+        public string Response { get; private set; }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException(nameof(info));
+            }
+
+            info.AddValue(nameof(Response), Response);
+            info.AddValue(nameof(StatusCode), (int)StatusCode);
+
+            base.GetObjectData(info, context);
+        }
+
+        protected HttpRequestException(SerializationInfo info, StreamingContext context)
+        {
+            Response = info.GetString(nameof(Response));
+            StatusCode = (HttpStatusCode)info.GetInt32(nameof(StatusCode));
+        }
+    }
+}

--- a/Graphite/Exceptions/HttpResponseMessageExtension.cs
+++ b/Graphite/Exceptions/HttpResponseMessageExtension.cs
@@ -1,0 +1,22 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace ahd.Graphite.Exceptions
+{
+    public static class HttpResponseMessageExtension
+    {
+        public static async Task EnsureSuccessStatusCodeAsync(this HttpResponseMessage response)
+        {
+            if (response.IsSuccessStatusCode)
+            {
+                return;
+            }
+
+            using (response.Content)
+            {
+                var content = await response.Content.ReadAsStringAsync();
+                throw new HttpRequestException(response.StatusCode, content);
+            }
+        }
+    }
+}

--- a/Graphite/Graphite.csproj
+++ b/Graphite/Graphite.csproj
@@ -76,6 +76,8 @@
     <Compile Include="Base\SummarizeFunction.cs" />
     <Compile Include="Datapoint.cs" />
     <Compile Include="Functions\IdentitySeriesList.cs" />
+    <Compile Include="Exceptions\HttpRequestException.cs" />
+    <Compile Include="Exceptions\HttpResponseMessageExtension.cs" />
     <Compile Include="Path\CharsGraphitePath.cs" />
     <Compile Include="Path\ModifiedGraphitePath.cs" />
     <Compile Include="Base\SeriesListBase.cs" />

--- a/Graphite/GraphiteClient.cs
+++ b/Graphite/GraphiteClient.cs
@@ -6,6 +6,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
 using ahd.Graphite.Base;
+using ahd.Graphite.Exceptions;
 
 namespace ahd.Graphite
 {
@@ -207,7 +208,7 @@ namespace ahd.Graphite
             using (var client = new HttpClient {BaseAddress = GetHttpApiUri()})
             {
                 var response = await client.GetAsync("/metrics/index.json");
-                response.EnsureSuccessStatusCode();
+                await response.EnsureSuccessStatusCodeAsync();
                 return await response.Content.ReadAsAsync<string[]>();
             }
         }
@@ -238,7 +239,7 @@ namespace ahd.Graphite
                     query, wildcards ? 1 : 0, fromUnix, untilUnix);
 
                 var response = await client.GetAsync(uri);
-                response.EnsureSuccessStatusCode();
+                await response.EnsureSuccessStatusCodeAsync();
                 return (await response.Content.ReadAsAsync<GraphiteFindResult>()).Metrics;
             }
         }
@@ -276,7 +277,7 @@ namespace ahd.Graphite
 
                 var body = new FormUrlEncodedContent(values);
                 var response = await client.PostAsync("/metrics/expand", body);
-                response.EnsureSuccessStatusCode();
+                await response.EnsureSuccessStatusCodeAsync();
                 return (await response.Content.ReadAsAsync<GraphiteExpandResult>()).Results;
             }
         }
@@ -359,7 +360,7 @@ namespace ahd.Graphite
                 var body = new StringContent(sb.ToString(), Encoding.UTF8, "application/x-www-form-urlencoded");
 
                 var response = await client.PostAsync("/render",body);
-                response.EnsureSuccessStatusCode();
+                await response.EnsureSuccessStatusCodeAsync();
 
                 return await response.Content.ReadAsAsync<GraphiteMetricData[]>();
             }


### PR DESCRIPTION
This is mostly for debugging purposes. The 500 reponse of a graphite server may include more detailed information or a stacktrace which will help debugging the error.

The implementation is heavily based on [this answer on SO](http://stackoverflow.com/a/27986405/19671)