### PR TITLE
allow usage of scale for division operations

### DIFF
--- a/Graphite.Test/GraphiteFunctionsTest.cs
+++ b/Graphite.Test/GraphiteFunctionsTest.cs
@@ -558,6 +558,10 @@ namespace ahd.Graphite.Test
         {
             var series = _series.Scale(10);
             Assert.AreEqual("scale(metric,10)", series.ToString());
+            series = _series.Scale(1000.1);
+            Assert.AreEqual("scale(metric,1000.1)", series.ToString());
+            series = _series.Scale(0.0005);
+            Assert.AreEqual("scale(metric,0.0005)", series.ToString());
         }
 
         [TestMethod]

--- a/Graphite/Base/SeriesListBase.cs
+++ b/Graphite/Base/SeriesListBase.cs
@@ -742,9 +742,9 @@ namespace ahd.Graphite.Base
         /// <summary>
         /// Takes one metric or a wildcard seriesList followed by a constant, and multiplies the datapoint by the constant provided at each point.
         /// </summary>
-        public SeriesListFunction Scale(int factor)
+        public SeriesListFunction Scale(double factor)
         {
-            return Binary("scale", factor);
+            return Binary("scale", factor.ToString(CultureInfo.InvariantCulture.NumberFormat));
         }
 
         /// <summary>


### PR DESCRIPTION
SeriesListBase.DivideSeries() documentation states

> To divide by a constant, use the scale() function
> (which is essentially a multiplication operation) and use the inverse of the dividend.
> (Division by 8 = multiplication by 1/8 or 0.125)