### PR TITLE
add missing cancellationtoken

### DIFF
--- a/Graphite/Base/SeriesListBase.cs
+++ b/Graphite/Base/SeriesListBase.cs
@@ -964,7 +964,7 @@ namespace ahd.Graphite.Base
 
         /// <summary>
         /// allows the metric paths to contain named variables.
-        /// Variable values can be specified or overriden in <see cref="GraphiteClient.GetMetricsDataAsync(ahd.Graphite.Base.SeriesListBase,string,string,System.Collections.Generic.IDictionary{string,string},System.Nullable{ulong})"/>
+        /// Variable values can be specified or overriden in <see cref="GraphiteClient.GetMetricsDataAsync(ahd.Graphite.Base.SeriesListBase,string,string,System.Collections.Generic.IDictionary{string,string},System.Nullable{ulong},System.Threading.CancellationToken)"/>
         /// </summary>
         /// <param name="defaultValues">default values for the template variables</param>
         /// <returns></returns>
@@ -975,7 +975,7 @@ namespace ahd.Graphite.Base
 
         /// <summary>
         /// allows the metric paths to contain positional variables.
-        /// Variable values can be specified or overriden in <see cref="GraphiteClient.GetMetricsDataAsync(ahd.Graphite.Base.SeriesListBase,string,string,System.Collections.Generic.IDictionary{string,string},System.Nullable{ulong})"/>
+        /// Variable values can be specified or overriden in <see cref="GraphiteClient.GetMetricsDataAsync(ahd.Graphite.Base.SeriesListBase,string,string,System.Collections.Generic.IDictionary{string,string},System.Nullable{ulong},System.Threading.CancellationToken)"/>
         /// </summary>
         /// <param name="defaultValues">default values for the template variables</param>
         /// <returns></returns>


### PR DESCRIPTION
#13 added the CancellationToken only to the sending methods. This adds the CancellationToken to all query methods.