### PR TITLE
Change standard numeric format string param for float

### DIFF
--- a/Graphite/Functions.tt
+++ b/Graphite/Functions.tt
@@ -557,8 +557,8 @@ class JParameter
 				return Name;
 			case "float":
 				if (Required || HasDefault)
-					return $"{Name}.ToString(\"r\", CultureInfo.InvariantCulture)";
-				return $"{Name}?.ToString(\"r\", CultureInfo.InvariantCulture)";
+					return $"{Name}.ToString(\"G17\", CultureInfo.InvariantCulture)";
+				return $"{Name}?.ToString(\"G17\", CultureInfo.InvariantCulture)";
 			default:
 				return "broken";
 		}


### PR DESCRIPTION
see information to r within microsoft documentation https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings

Note: Recommended for the BigInteger type only. For Double types, use "G17"; for Single types, use "G9".