### PR TITLE
extend connection check

### DIFF
--- a/Graphite/CarbonConnectionPool.cs
+++ b/Graphite/CarbonConnectionPool.cs
@@ -136,6 +136,12 @@ namespace ahd.Graphite
             try
             {
                 await _formatter.TestConnectionAsync(client.GetStream(), cancellationToken).ConfigureAwait(false);
+                //https://stackoverflow.com/a/2661876/19671
+                var socket = client.Client;
+                if (!socket.Connected) return false;
+                var poll = socket.Poll(1000, SelectMode.SelectRead);
+                var empty = socket.Available == 0;
+                if (poll && empty) return false;
                 return true;
             }
             catch (IOException ex) when (ex.InnerException is SocketException se && CheckSocketException(se))


### PR DESCRIPTION
Right now the connection might have been close and even the write to check if the connection is still alive may succeed. This change additionally polls the socket to make sure it's still usable.

Without this change we can reproduce the error when using the connection pool on a linux machine against go-carbon when there was no data transmitted for 5 minutes. It looks like there is a [fixed timeout of 2 minutes](https://github.com/go-graphite/go-carbon/blob/04bb3dc867a2bef89e6489923e1ecd0270883aaa/receiver/tcp/tcp.go#L273) for all connections to go-carbon. The connection check was successful but the subsequent write failed with:
```
System.IO.IOException: Unable to write data to the transport connection: Broken pipe.
 ---> System.Net.Sockets.SocketException (32): Broken pipe
```
which should have been detected by `TestConnectionAsync`.